### PR TITLE
添加页面状态保留功能

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -280,9 +280,13 @@ legend {
 .sidebar li {
     text-align:center;
     width:100%;
-    padding:10px 0;
     font-size: 14px;
 }
+.sidebar_list li > a {
+    display: block; 
+    padding:10px 0;
+}
+
 .sidebar li:hover,
  .sidebar li.cur{
     background:#EDEDED;

--- a/index.html
+++ b/index.html
@@ -1982,32 +1982,32 @@
         <!-- 左侧边栏导航 [[ -->
         <aside class="sidebar col-sub">
               <ul class="sidebar_list radius">
-                    <li class="cur">
-                      <a href="javascript:scroll(0,0);">手册/工具</a>
+                    <li>
+                      <a href="#tools">手册/工具</a>
                     </li>
                     <li>
-                      <a href="javascript:scroll(0,0);">常用组件/插件</a>
+                      <a href="#plugin">常用组件/插件</a>
                     </li>
                     <li>
-                      <a href="javascript:scroll(0,0);">框架/库</a>
+                      <a href="#framework">框架/库</a>
                     </li>
                     <li>
-                      <a href="javascript:scroll(0,0);">方案荟萃/常见问题</a>
+                      <a href="#qa">方案荟萃/常见问题</a>
                     </li>
                     <li>
-                      <a href="javascript:scroll(0,0);">资料/书籍/教程</a>
+                      <a href="#course">资料/书籍/教程</a>
                     </li>
                     <li>
-                      <a href="javascript:scroll(0,0);">博客/社区</a>
+                      <a href="#blog">博客/社区</a>
                     </li>
                     <li>
-                      <a href="javascript:scroll(0,0);">电子读物/公众号/微博号</a>
+                      <a href="#weibo">电子读物/公众号/微博号</a>
                     </li>
                     <li>
-                      <a href="javascript:scroll(0,0);">活动/会议</a>
+                      <a href="#activity">活动/会议</a>
                     </li>
-                    <li><a href="javascript:scroll(0,0);">佳文选摘</a></li>
-                    <li><a href="javascript:scroll(0,0);">Demo</a></li>
+                    <li><a href="#article">佳文选摘</a></li>
+                    <li><a href="#demo">Demo</a></li>
                     <li class="side-about"><a href="about.html">关于本站</a></li>
               </ul>
         </aside>
@@ -2036,30 +2036,6 @@
     </footer>
   </article>
   <script src="http://apps.bdimg.com/libs/jquery/1.9.1/jquery.min.js"></script>
-  <script type="text/javascript">
-      $(function(){ 
-          var $li=$("aside ul li")
-          var $area=$("article.mainarea");
-          var $win=$(window).height();
-              /*显示不同区块*/
-              $li.click(function(){
-                          $(this).addClass('cur').siblings().removeClass('cur');
-                var $que=$(this).index();
-                $area.eq($que).show().siblings("article").hide();  
-              })
-              /*页面向下滚动侧边栏和主内容进行相应行为*/
-              $(window).scroll(function(){
-              
-              var $Height=$(window).scrollTop();  
-              
-              if($Height>105){
-                    $(".sidebar_list").addClass('over');
-              } else{
-                    $(".sidebar_list").removeClass('over');
-                    }
-              })
-        $('.col-main .mainarea').css("min-height",$win-269+'px');
-        })
-</script>
+  <script type="text/javascript" src="js/page.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -48,7 +48,10 @@
         <section class='col-main'>
           <p class="tips">温馨提示：为了您的体验更佳，请在PC端使用</p>
           <!--手册、工具-->
-          <article class="mainarea item" style="display:block;">
+          <article class="mainarea" style="display: block;">
+            loading...
+          </article>
+          <article class="mainarea item">
                 <section class="mod">
                             <h3>手册</h3>
                             <section class="sub_mod">

--- a/js/page.js
+++ b/js/page.js
@@ -1,0 +1,47 @@
+$(function () {
+    var $li = $('aside ul li');
+    var $area = $('article.mainarea');
+    var $win = $(window).height();
+
+    // 渲染页面
+    var renderUi = function () {
+        var index = getCurrentIndex();
+
+        $li.eq(index).addClass('cur').siblings().removeClass('cur');
+        $area.eq(index).show().siblings('article').hide();
+
+        window.scrollTo(0, 0);
+    };
+
+    // 获取当前需要显示的搜索
+    var getCurrentIndex = function () {
+        var hash = window.location.hash.substr(1);
+        var $elem;
+
+        if (hash) {
+            $elem = $li.find('a[href="#' + hash + '"]');
+        }
+
+        // 如果没有hash或者hash错误则默认为第0个
+        return $elem && $elem.length ? $elem.parent().index() : 0;
+    };
+
+    // 绑定hash改变时触发渲染
+    $(window).on('hashchange', renderUi);
+
+    // 默认根据hash渲染
+    renderUi();
+
+    /*页面向下滚动侧边栏和主内容进行相应行为*/
+    $(window).scroll(function () {
+        var $Height = $(window).scrollTop();
+
+        if ($Height > 105) {
+            $('.sidebar_list').addClass('over');
+        }
+        else {
+            $('.sidebar_list').removeClass('over');
+        }
+    });
+    $('.col-main .mainarea').css('min-height', $win - 269 + 'px');
+});

--- a/js/page.js
+++ b/js/page.js
@@ -1,6 +1,6 @@
 $(function () {
     var $li = $('aside ul li');
-    var $area = $('article.mainarea');
+    var $area = $('article.mainarea.item');
     var $win = $(window).height();
 
     // 渲染页面


### PR DESCRIPTION
## 由来

今天在某个群有人前端fe想看有没有哪个网站收集了一些干货，和一些博客的链接，我就果断的发了下`醉牛前端`，但由于我想让其直接看某个分类，却发现不能让其通过我分享的url直接打开目录的页面，由于我在想要不要通过`hash`来保留页面状态。
## 处理思路

修改导航的链接为`#hash`的锚点，绑定`hashchange`事件，统一接管渲染，页面默认显示loading，加载完再根据`hash`渲染下默认打开的页面，做到状态保留～

但 [hashchange兼容性](http://caniuse.com/#feat=hashchange) 到ie8，个人感觉也没有问题～

为了真实的看下效果，这里是我临时搭建的一个[预览地址](https://github.xuexb.com/notebook/index.html#blog)

ps: 导航中的`hash`起的名称可能不太友好～

---

当然只是个人看法哈～
